### PR TITLE
Fix Fernet.encrypt() to actually return bytes.

### DIFF
--- a/fernet.py
+++ b/fernet.py
@@ -38,12 +38,12 @@ class Fernet:
     def generate_key(cls):
         return base64.urlsafe_b64encode(os.urandom(32))
 
-    def encrypt(self, data) -> bytes:
+    def encrypt(self, data):
         current_time = int(time.time())
         iv = os.urandom(16)
         return self._encrypt_from_parts(data, current_time, iv)
 
-    def _encrypt_from_parts(self, data, current_time, iv) -> bytes:
+    def _encrypt_from_parts(self, data, current_time, iv):
         encrypter = Encrypter(AESModeOfOperationCBC(self._encryption_key, iv))
         ciphertext = encrypter.feed(data)
         ciphertext += encrypter.feed()
@@ -55,7 +55,7 @@ class Fernet:
 
         return base64.urlsafe_b64encode(basic_parts + hmactext.digest())
 
-    def decrypt(self, token, ttl=None) -> bytes:
+    def decrypt(self, token, ttl=None):
         if not isinstance(token, bytes):
             raise TypeError("token must be bytes.")
 

--- a/fernet.py
+++ b/fernet.py
@@ -23,6 +23,10 @@ class InvalidSignature(Exception):
 
 
 class Fernet:
+    """
+    Pure python Ferent module
+    see https://github.com/fernet/spec/blob/master/Spec.md
+    """
     def __init__(self, key):
         if not isinstance(key, bytes):
             raise TypeError("key must be bytes.")

--- a/fernet.py
+++ b/fernet.py
@@ -1,12 +1,16 @@
 import base64
 import binascii
-import hmac as HMAC
+import hmac
 import time
 import os
 import struct
-
 from pyaes import AESModeOfOperationCBC, Encrypter, Decrypter
 
+__all__ = [
+    "InvalidSignature",
+    "InvalidToken",
+    "Fernet"
+]
 _MAX_CLOCK_SKEW = 60
 
 
@@ -19,18 +23,13 @@ class InvalidSignature(Exception):
 
 
 class Fernet:
-    """Pure python Ferent module
-    see https://github.com/fernet/spec/blob/master/Spec.md
-    """
     def __init__(self, key):
         if not isinstance(key, bytes):
             raise TypeError("key must be bytes.")
 
         key = base64.urlsafe_b64decode(key)
         if len(key) != 32:
-            raise ValueError(
-                "Fernet key must be 32 url-safe base64-encoded bytes."
-            )
+            raise ValueError("Fernet key must be 32 url-safe base64-encoded bytes.")
 
         self._signing_key = key[:16]
         self._encryption_key = key[16:]
@@ -39,25 +38,24 @@ class Fernet:
     def generate_key(cls):
         return base64.urlsafe_b64encode(os.urandom(32))
 
-    def encrypt(self, data):
+    def encrypt(self, data) -> bytes:
         current_time = int(time.time())
         iv = os.urandom(16)
-        self._encrypt_from_parts(data, current_time, iv)
+        return self._encrypt_from_parts(data, current_time, iv)
 
-    def _encrypt_from_parts(self, data, current_time, iv):
+    def _encrypt_from_parts(self, data, current_time, iv) -> bytes:
         encrypter = Encrypter(AESModeOfOperationCBC(self._encryption_key, iv))
         ciphertext = encrypter.feed(data)
         ciphertext += encrypter.feed()
 
-        basic_parts = (b"\x80" + struct.pack(">Q", current_time)
-                       + iv + ciphertext)
+        basic_parts = (b"\x80" + struct.pack(">Q", current_time) + iv + ciphertext)
 
-        hmac = HMAC.new(self._signing_key, digestmod='sha256')
-        hmac.update(basic_parts)
+        hmactext = hmac.new(self._signing_key, digestmod='sha256')
+        hmactext.update(basic_parts)
 
-        return base64.urlsafe_b64encode(basic_parts + hmac.digest())
+        return base64.urlsafe_b64encode(basic_parts + hmactext.digest())
 
-    def decrypt(self, token, ttl=None):
+    def decrypt(self, token, ttl=None) -> bytes:
         if not isinstance(token, bytes):
             raise TypeError("token must be bytes.")
 
@@ -82,9 +80,9 @@ class Fernet:
             if current_time + _MAX_CLOCK_SKEW < timestamp:
                 raise InvalidToken
 
-        h = HMAC.new(self._signing_key, digestmod='sha256')
-        h.update(data[:-32])
-        if not HMAC.compare_digest(h.digest(), data[-32:]):
+        hmactext = hmac.new(self._signing_key, digestmod='sha256')
+        hmactext.update(data[:-32])
+        if not hmac.compare_digest(hmactext.digest(), data[-32:]):
             raise InvalidToken
 
         iv = data[9:25]


### PR DESCRIPTION
Previously was returning None, without this change this library is broken. Consider incrementing version and release to PyPI.
